### PR TITLE
feat(us6): filtersök på antal sidor (lt/eq/gt)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,7 +37,7 @@
         placeholder="Sök efter titel, författare, bibliotek..."
         />
 
-  <!-- US5: sidfilter (NYTT) -->
+  <!-- US6: sidfilter (NYTT) -->
   <select id="pagesOp" aria-label="Sidfilter">
     <option value="">sidor…</option>
     <option value="lt">&lt;</option>

--- a/public/index.html
+++ b/public/index.html
@@ -35,8 +35,19 @@
         type="text"
         id="searchInput"
         placeholder="Sök efter titel, författare, bibliotek..."
-  />
-    <button id="searchButton">🔍 Sök</button>
+        />
+
+  <!-- US5: sidfilter (NYTT) -->
+  <select id="pagesOp" aria-label="Sidfilter">
+    <option value="">sidor…</option>
+    <option value="lt">&lt;</option>
+    <option value="eq">=</option>
+    <option value="gt">&gt;</option>
+  </select>
+
+  <input id="pages" type="number" min="0" step="1" inputmode="numeric" placeholder="antal" style="width:7rem;" />
+
+  <button id="searchButton" type="button">🔍 Sök</button>
 </div>
 
 <!-- Jag ändrade button oneclick itll id searchbutton eftersom 

--- a/public/main.js
+++ b/public/main.js
@@ -3,7 +3,7 @@
 // Skript-kod flyttad från index.html samt innehåll för user story 5:
 
 /* ===========================
-   US5 – Textsök + sidfilter
+   US6 – Textsök + sidfilter
    =========================== */
 
 // Hämta UI-element (stöder både #searchBtn och äldre #searchButton)

--- a/public/main.js
+++ b/public/main.js
@@ -2,58 +2,73 @@
 
 // Skript-kod flyttad från index.html samt innehåll för user story 5:
 
-async function search() {
-  const query = document.getElementById("searchInput").value;
+/* ===========================
+   US5 – Textsök + sidfilter
+   =========================== */
+
+// Hämta UI-element (stöder både #searchBtn och äldre #searchButton)
+const elsText = {
+  searchInput: document.getElementById('searchInput'),
+  searchBtn:   document.getElementById('searchBtn') || document.getElementById('searchButton'),
+  pagesOp:     document.getElementById('pagesOp'),
+  pages:       document.getElementById('pages'),
+  results:     document.getElementById('results'), // delas med US7
+};
+
+// Koppla klick på sökknappen -> nya US5-funktionen
+elsText.searchBtn?.addEventListener('click', searchText);
+
+// Backend-anrop till nya US5-endpointen
+async function searchText() {
+  const q       = (elsText.searchInput?.value ?? '').trim();
+  const pages   = (elsText.pages?.value ?? '').trim();
+  const pagesOp = elsText.pagesOp?.value ?? '';
+
+  const params = new URLSearchParams();
+  if (q) params.set('q', q);
+  if (pages && pagesOp) {
+    params.set('pages', pages);     // heltal
+    params.set('pagesOp', pagesOp); // lt | eq | gt
+  }
+
   try {
-    const res = await fetch(
-      `http://localhost:4567/api/Books/${encodeURIComponent(query)}`
-    );
+    const res = await fetch(`/api/search-text?${params.toString()}`);
     if (!res.ok) throw new Error(`Serverfel: ${res.status}`);
-    const books = await res.json();
-
-    const resultsDiv = document.getElementById("results");
-    resultsDiv.innerHTML = "";
-
-    if (books.length === 0) {
-      resultsDiv.innerHTML = "<p>Inga resultat hittades.</p>";
-      return;
-    }
-
-    books.forEach((book) => {
-      const meta = typeof book.description === "string"
-        ? JSON.parse(book.description)
-        : book.description;
-
-      const imageName = book.filename?.replace(/\.[^/.]+$/, ".jpg") || "ingen-bild.jpg";
-      const imagePath = `./images/${imageName}`;
-
-      resultsDiv.innerHTML += `
-        <div class="book">
-          <img
-            src="${imagePath}"
-            alt="Bokomslag"
-            onerror="this.onerror=null;this.src='/images/ingen-bild.jpg';"
-          />
-          <div class="info">
-            <h2>${meta.titel || "Okänd titel"}</h2>
-            <p><strong>Författare:</strong> ${meta.författare || "Okänd"}</p>
-            <p><strong>Format:</strong> ${meta.format || "Okänt format"}</p>
-            <p><strong>Bibliotek:</strong> ${meta.plats || "Ej angiven"}</p>
-            <p><strong>GPS:</strong> ${
-              meta.gps
-                ? `Lat: ${meta.gps[0]}, Lng: ${meta.gps[1]}`
-                : "Ej angiven"
-            }</p>
-          </div>
-        </div>
-      `;
-    });
-  } catch (error) {
-    console.error("Fel vid sökning:", error);
-    const resultsDiv = document.getElementById("results");
-    resultsDiv.innerHTML = `<p>Ett fel uppstod vid sökningen: ${error.message}</p>`;
+    const items = await res.json();
+    renderText(items);
+  } catch (err) {
+    console.error(err);
+    elsText.results.innerHTML = `<div>Ett fel uppstod: ${err.message}</div>`;
   }
 }
+
+// Rendera US5-resultat (utan karta)
+function renderText(items) {
+  elsText.results.innerHTML = '';
+
+  if (!Array.isArray(items) || items.length === 0) {
+    elsText.results.innerHTML = '<div>Inga träffar.</div>';
+    return;
+  }
+
+  for (const it of items) {
+    const title = it.title || it.filename || '(utan titel)';
+    const parts = [];
+    if (it.author) parts.push(`av ${it.author}`);
+    if (Number.isFinite(Number(it.pages))) parts.push(`${it.pages} sidor`);
+
+    const row = document.createElement('div');
+    row.style.margin = '1rem 0';
+    row.innerHTML = `<strong>${title}</strong>${parts.length ? `<div>${parts.join(' — ')}</div>` : ''}`;
+    elsText.results.appendChild(row);
+  }
+}
+
+// Back-compat shim: om något fortfarande kallar `search()`, vidarebefordra till nya US5
+function search() {
+  return searchText();
+}
+
 
 // Bonus: gör så att Enter-knappen triggar sökningen
 //document.addEventListener("DOMContentLoaded", () => {

--- a/server/server.js
+++ b/server/server.js
@@ -53,20 +53,7 @@ app.get('/api/Books', async (request, response) => {
   response.json(result);
 });
 
-// User Story 5:
-app.get('/api/Books/:searchTerm', async (request, response) => {
-  let searchTerm = `%${request.params.searchTerm.toLowerCase()}%`;
 
-  let result = await query(`
-    SELECT *
-    FROM Books
-    WHERE 
-      LOWER(filename) LIKE ? OR
-      LOWER(description) LIKE ?
-  `, [searchTerm, searchTerm]);
-
-  response.json(result);
-});
 
 // === US7: /api/search — geo-only (kräver geoLat, geoLng, geoRadiusKm) ===
 app.get('/api/search', async (req, res) => {
@@ -108,6 +95,73 @@ app.get('/api/search', async (req, res) => {
     res.status(500).json({ error: 'Serverfel i geo-sökningen' });
   }
 });
+
+// === US5: text + sidfilter (lt|eq|gt) ===
+app.get('/api/search-text', async (req, res) => {
+  try {
+    const q = (req.query.q ?? '').trim();
+
+    const opKey    = req.query.pagesOp; // "lt" | "eq" | "gt"
+    const rawPages = (req.query.pages ?? '').toString().trim();
+    const pagesVal = rawPages === '' ? undefined : Number(rawPages);
+
+    const OPS = { lt: '<', eq: '=', gt: '>' };
+    if (pagesVal !== undefined) {
+      if (!Number.isInteger(pagesVal) || pagesVal < 0) {
+        return res.status(400).json({ error: 'pages måste vara heltal ≥ 0' });
+      }
+      if (!OPS[opKey]) {
+        return res.status(400).json({ error: 'pagesOp måste vara lt, eq eller gt' });
+      }
+    }
+
+    // JSON-fält (sv/eng)
+    const titleExpr = `COALESCE(
+      JSON_UNQUOTE(JSON_EXTRACT(description,'$.title')),
+      JSON_UNQUOTE(JSON_EXTRACT(description,'$.titel'))
+    )`;
+    const authorExpr = `COALESCE(
+      JSON_UNQUOTE(JSON_EXTRACT(description,'$.author')),
+      JSON_UNQUOTE(JSON_EXTRACT(description,'$.författare'))
+    )`;
+    const pagesExpr = `CAST(IFNULL(
+      JSON_UNQUOTE(JSON_EXTRACT(description,'$.pages')),
+      JSON_UNQUOTE(JSON_EXTRACT(description,'$.antal_sidor'))
+    ) AS UNSIGNED)`;
+
+    let sql = `
+      SELECT id, filename,
+             ${titleExpr}  AS title,
+             ${authorExpr} AS author,
+             ${pagesExpr}  AS pages
+      FROM Books
+    `;
+
+    const where  = [];
+    const params = [];
+
+    if (q) {
+      const like = `%${q}%`;
+      where.push(`(${titleExpr} LIKE ? OR ${authorExpr} LIKE ? OR filename LIKE ? OR CAST(description AS CHAR) LIKE ?)`);
+      params.push(like, like, like, like);
+    }
+
+    if (pagesVal !== undefined) {
+      where.push(`${pagesExpr} ${OPS[opKey]} ?`);
+      params.push(pagesVal);
+    }
+
+    if (where.length) sql += ` WHERE ${where.join(' AND ')}`;
+    sql += ` ORDER BY COALESCE(${titleExpr}, filename) ASC LIMIT 100`;
+
+    const rows = await query(sql, params);
+    res.json(rows);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: 'Search failed' });
+  }
+});
+
 
 
 export default db;

--- a/server/server.js
+++ b/server/server.js
@@ -96,7 +96,7 @@ app.get('/api/search', async (req, res) => {
   }
 });
 
-// === US5: text + sidfilter (lt|eq|gt) ===
+// === US6: text + sidfilter (lt|eq|gt) ===
 app.get('/api/search-text', async (req, res) => {
   try {
     const q = (req.query.q ?? '').trim();


### PR DESCRIPTION
US6: Filtersök på antal sidor (lt/eq/gt)

Syfte:
Lägg till möjlighet att filtrera sökresultat på antal sidor med operatorerna **<**, **=**, **>**.

Vad som ingår
- UI i `index.html`:
  - `<select id="pagesOp">` för operator (lt/eq/gt)
  - `<input id="pages">` för antal sidor
- Logik i `public/main.js`:
  - Läser `pagesOp` och `pages` och skickar som query-params
- Backend i `server/server.js`:
  - Utökning av `/api/search-text` som tolkar `pagesOp` + `pages` och filtrerar mot JSON-fält (`pages`/`antal_sidor`)

> **Obs:** Textsök fanns sedan tidigare och återanvänds. Denna PR handlar om **sidfiltret** och kopplingen UI ↔ backend.

